### PR TITLE
PHP-FPM の標準ログ出力を設定ファイルで指定するのではなくシンボリックリンクに変更

### DIFF
--- a/docker/app/php-fpm/Dockerfile
+++ b/docker/app/php-fpm/Dockerfile
@@ -41,8 +41,17 @@ RUN \
     # Unixソケット通信用のディレクトリを作成
     && mkdir -p \
     /run/php-fpm \
+    /var/log/php-fpm \
     && chown -R ${USERNAME}:${USERNAME} \
-    /run/php-fpm
+    /run/php-fpm \
+    /var/log/php-fpm \
+    # NOTE: アクセスログ、エラーログ、スローログをdockerログに転送するためシンボリックリンクを作成
+    # NOTE: php-fpm closes STDOUT on startup, so sending logs to /proc/self/fd/1 does not work.
+    # NOTE: https://bugs.php.net/bug.php?id=73886
+    && ln -sf /proc/self/fd/2 /var/log/php-fpm/error.log \
+    && ln -sf /proc/self/fd/2 /var/log/php-fpm/www-access.log \
+    && ln -sf /proc/self/fd/2 /var/log/php-fpm/www-error.log \
+    && ln -sf /proc/self/fd/2 /var/log/php-fpm/www-slow.log
 
 # PHP-FPM の設定ファイルをコピー
 COPY --from=php-fpm-ctx ./php-fpm.conf /etc/php-fpm.conf

--- a/docker/app/php-fpm/php-fpm.conf
+++ b/docker/app/php-fpm/php-fpm.conf
@@ -23,9 +23,7 @@ pid = /run/php-fpm/php-fpm.pid
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; in a local file.
 ; Default Value: /var/log/php-fpm.log
-; NOTE: ログ出力先を標準出力に変更
-; error_log = /var/log/php-fpm/error.log
-error_log = /proc/self/fd/2
+error_log = /var/log/php-fpm/error.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/docker/app/php-fpm/php-fpm.d/www.conf
+++ b/docker/app/php-fpm/php-fpm.d/www.conf
@@ -282,10 +282,7 @@ ping.path = /ping
 ; The access log file
 ; Default: not set
 ;access.log = log/$pool.access.log
-; NOTE: php-fpm closes STDOUT on startup, so sending logs to /proc/self/fd/1 does not work.
-; NOTE: https://bugs.php.net/bug.php?id=73886
-; NOTE: アクセスログを有効にし、かつログ出力先を標準出力に変更
-access.log = /proc/self/fd/2
+access.log = /var/log/php-fpm/www-access.log
 
 ; The access log format.
 ; The following syntax is allowed
@@ -349,9 +346,7 @@ access.log = /proc/self/fd/2
 ; The log file for slow requests
 ; Default Value: not set
 ; Note: slowlog is mandatory if request_slowlog_timeout is set
-; NOTE: Slowログ出力先を標準出力に変更
-; slowlog = /var/log/php-fpm/www-slow.log
-slowlog = /proc/self/fd/2
+slowlog = /var/log/php-fpm/www-slow.log
 
 ; The timeout for serving a single request after which a PHP backtrace will be
 ; dumped to the 'slowlog' file. A value of '0s' means 'off'.


### PR DESCRIPTION
Fixes #1